### PR TITLE
Change Download Url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
-default['notepadplusplus']['url']          = "http://download.tuxfamily.org/notepadplus/5.9.8/npp.5.9.8.Installer.exe"
+default['notepadplusplus']['url']          = "https://notepad-plus-plus.org/repository/6.x/6.8.3/npp.6.8.3.Installer.exe"
 default['notepadplusplus']['package_name'] = "Notepad++"


### PR DESCRIPTION
The previous url resulted in a 404 for me, so I updated to the current one from the notepad-plus-plus site.
